### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python"
+run = "python2 -m pip install -r requirements.txt"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Get_R_S_Z_RawTx
+[![Run on Repl.it](https://repl.it/badge/github/hubsen1980/Get_R_S_Z_RawTx)](https://repl.it/github/hubsen1980/Get_R_S_Z_RawTx)
 Get R_S_Z VALUES from bitcoin RawTx 
 
 before you run it you must edit Get_R_S_Z_RawTx.py


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).